### PR TITLE
Fixed issue mapping Keystone endpoints in the getEndpoints function.

### DIFF
--- a/src/JSTACK.Comm.js
+++ b/src/JSTACK.Comm.js
@@ -198,7 +198,7 @@ JSTACK.Comm = (function (JS, undefined) {
         if (JSTACK.Keystone.params.version === 3) {
             type = type.split('URL')[0];
             for (var e in serv.endpoints) {
-                if (serv.endpoints[e].region === region && serv.endpoints[e].interface === type) {
+                if ((serv.endpoints[e].region === region || serv.endpoints[e].region_id === region) && serv.endpoints[e].interface === type) {
                     endpoint = serv.endpoints[e].url;
                     break;
                 }

--- a/src/JSTACK.Comm.js
+++ b/src/JSTACK.Comm.js
@@ -198,7 +198,8 @@ JSTACK.Comm = (function (JS, undefined) {
         if (JSTACK.Keystone.params.version === 3) {
             type = type.split('URL')[0];
             for (var e in serv.endpoints) {
-                if ((serv.endpoints[e].region === region || serv.endpoints[e].region_id === region) && serv.endpoints[e].interface === type) {
+                if ((serv.endpoints[e].region === region || serv.endpoints[e].region_id === region) && 
+                       serv.endpoints[e].interface === type) {
                     endpoint = serv.endpoints[e].url;
                     break;
                 }


### PR DESCRIPTION
This issue was caused by a new parameter - region_id - which prevented public endpoints to be retrieved correctly. This only applies for Keystone v3.